### PR TITLE
Removing the error boolean in LoginInteractor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '24.0.1'
+    buildToolsVersion '24.0.3'
 
     defaultConfig {
         applicationId 'com.antonioleiva.androidmvp'

--- a/app/src/main/java/com/antonioleiva/mvpexample/app/Login/LoginInteractorImpl.java
+++ b/app/src/main/java/com/antonioleiva/mvpexample/app/Login/LoginInteractorImpl.java
@@ -10,20 +10,15 @@ public class LoginInteractorImpl implements LoginInteractor {
         // Mock login. I'm creating a handler to delay the answer a couple of seconds
         new Handler().postDelayed(new Runnable() {
             @Override public void run() {
-                boolean error = false;
-                if (TextUtils.isEmpty(username)){
+                if (TextUtils.isEmpty(username)) {
                     listener.onUsernameError();
-                    error = true;
                     return;
                 }
-                if (TextUtils.isEmpty(password)){
+                if (TextUtils.isEmpty(password)) {
                     listener.onPasswordError();
-                    error = true;
                     return;
                 }
-                if (!error){
-                    listener.onSuccess();
-                }
+                listener.onSuccess();
             }
         }, 2000);
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.2'
     }
 }
 


### PR DESCRIPTION
There is no need for the error flag now since #24 added return statements inside the conditionals.
Also, updating buildToolsVersion and Gradle versions.